### PR TITLE
feat: use workflow name in treeview by default

### DIFF
--- a/src/TreeViewProvider.ts
+++ b/src/TreeViewProvider.ts
@@ -25,7 +25,7 @@ export class TreeViewProvider implements vscode.TreeDataProvider<TreeviewItem> {
         this.getWorkflowFiles().map(
           (file) =>
             new TreeviewItem(
-              path.basename(file.filePath),
+              file.name || path.basename(file.filePath),
               file.filePath,
               vscode.TreeItemCollapsibleState.Collapsed,
               file.steps


### PR DESCRIPTION
#### Description
use workflow name in treeview instead of filename by default

#### Resolves
#2 