### PR TITLE
feat: open workflow file on item click

### DIFF
--- a/src/TreeViewProvider.ts
+++ b/src/TreeViewProvider.ts
@@ -72,11 +72,11 @@ export class TreeviewItem extends vscode.TreeItem {
       this.iconPath = vscode.Uri.parse(
         `https://app.openfn.org/images/adaptors/${adaptor_name}-square.png`
       );
-      this.command = {
-        command: "openfn-workflows.itemclicked",
-        title: "OpenFn Workflows ItemClicked",
-        arguments: [this],
-      };
     }
+    this.command = {
+      command: "openfn-workflows.itemclicked",
+      title: "OpenFn Workflows ItemClicked",
+      arguments: [this],
+    };
   }
 }


### PR DESCRIPTION
#### Description
When a workflow is clicked in the OpenFn Activity view. Open the workflow file, instead of expanding/collapsing the view

<img width="586" alt="Screenshot 2025-01-13 at 3 01 46 PM" src="https://github.com/user-attachments/assets/8beb54bc-6ec8-4068-bb85-628b72b41096" />

#### Resolves 
#4

