### PR TITLE
feat: show adaptor name & version next to step

### DIFF
--- a/src/TreeViewProvider.ts
+++ b/src/TreeViewProvider.ts
@@ -72,6 +72,7 @@ export class TreeviewItem extends vscode.TreeItem {
       this.iconPath = vscode.Uri.parse(
         `https://app.openfn.org/images/adaptors/${adaptor_name}-square.png`
       );
+      this.description = this.adaptor;
     }
     this.command = {
       command: "openfn-workflows.itemclicked",


### PR DESCRIPTION
#### Description
Shows adaptor name and version next to the step in the OpenFn activity view
<img width="586" alt="Screenshot 2025-01-13 at 3 31 30 PM" src="https://github.com/user-attachments/assets/e5ce32e2-85da-488a-b3e9-0d185d354c56" />

#### Resolves
#3 