### PR TITLE
fix: ignore tmp directory when picking workflow files

### DIFF
--- a/src/OpenfnExtension.ts
+++ b/src/OpenfnExtension.ts
@@ -55,6 +55,12 @@ export class OpenFnExtension implements vscode.Disposable {
     this.workflowManager.api.commands.registerCommand(
       "openfn.run-workflows",
       async () => {
+        if (this.workflowManager.workflowFiles.length === 0) {
+          this.workflowManager.api.window.showWarningMessage(
+            "No workflow found the the workspace for execution"
+          );
+          return;
+        }
         let workflowInfo: { path: string; name?: string } | undefined;
         if (this.workflowManager.workflowFiles.length === 1) {
           workflowInfo = {

--- a/src/managers/WorkflowManager.ts
+++ b/src/managers/WorkflowManager.ts
@@ -96,7 +96,7 @@ export class WorkflowManager implements vscode.Disposable {
   private async updateWorkflowFiles() {
     const workflowUris = await this.api.workspace.findFiles(
       "**/*workflow*.json", // consider yml soon!
-      "**/node_modules/**"
+      "{**/node_modules/**,**/tmp/**}"
     );
 
     const res = await Promise.all(
@@ -112,7 +112,7 @@ export class WorkflowManager implements vscode.Disposable {
 
     const workflows: WorkflowData[] = [];
     for (const w of res) {
-      if (!w.success) {
+      if (!w.success || !w.result.workflow) {
         // shout about parse error in a file
         continue;
       }


### PR DESCRIPTION
#### Description
Issue was that, after generating you initial output file. The vscode extension starts to pick up the output file as a workflow file causing the workflow parsing to error. 

This PR ignore the directory `/tmp` when finding workflow files. 

#21
