### PR TITLE
feat: accept input source before executing workflow

### DIFF
--- a/src/OpenfnExtension.ts
+++ b/src/OpenfnExtension.ts
@@ -1,13 +1,12 @@
-import * as vscode from "vscode";
 import * as path from "path";
+import * as vscode from "vscode";
 
-import { WorkflowManager } from "./managers/WorkflowManager";
-import { TreeviewItem, TreeViewProvider } from "./TreeViewProvider";
-import { StatusBarManager } from "./managers/StatusBarManager";
-import registerSemanticColoring from "./SemanticColoring";
-import { runWorkflow } from "./workflowRunner";
 import { CompletionManager } from "./managers/CompletionManager";
 import { SourceManager } from "./managers/SourceManager";
+import { StatusBarManager } from "./managers/StatusBarManager";
+import { WorkflowManager } from "./managers/WorkflowManager";
+import registerSemanticColoring from "./SemanticColoring";
+import { TreeviewItem, TreeViewProvider } from "./TreeViewProvider";
 import { debounce } from "./utils/debounce";
 
 const supportedExtension = [".fn", ".js", ".ofn", ".openfn"];
@@ -131,7 +130,7 @@ export class OpenFnExtension implements vscode.Disposable {
             workflowInfo = { path: result.workflowPath, name: result.label };
         }
         if (workflowInfo) {
-          runWorkflow(workflowInfo, workflowManager.workspaceUri);
+          workflowManager.runWorkflow(workflowInfo);
         }
       }
     );
@@ -139,10 +138,7 @@ export class OpenFnExtension implements vscode.Disposable {
     this.workflowManager.api.commands.registerCommand(
       "openfn.workflow.item.run",
       (item: TreeviewItem) => {
-        runWorkflow(
-          { path: item.filePath, name: item.label },
-          workflowManager.workspaceUri
-        );
+        workflowManager.runWorkflow({ path: item.filePath, name: item.label });
       }
     );
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,7 +21,11 @@ export function activate(context: vscode.ExtensionContext) {
   const activeWorkspace = workspaceFolder[0];
 
   // start
-  const workflowManager = new WorkflowManager(vscode, activeWorkspace.uri);
+  const workflowManager = new WorkflowManager(
+    vscode,
+    activeWorkspace.uri,
+    context.workspaceState
+  );
   const treeviewProvider = new TreeViewProvider(
     () => workflowManager.workflowFiles
   );

--- a/src/managers/WorkflowManager.ts
+++ b/src/managers/WorkflowManager.ts
@@ -4,6 +4,7 @@ import { WorkflowData, WorkflowJson } from "../types";
 import parseJson from "../utils/parseJson";
 import { OpenfnRcManager } from "./OpenfnRcManager";
 import { runWorkflowHelper } from "../workflowRunner";
+import { existsSync } from "fs";
 
 interface ActiveFileMeta {
   isJob: boolean;
@@ -61,6 +62,7 @@ export class WorkflowManager implements vscode.Disposable {
   getWorkflowRecentInput(workflowPath: string) {
     const rInputs = this.storage.get<Record<string, string>>(RECENT_INPUTS_KEY);
     if (!rInputs || !rInputs[workflowPath]) return undefined;
+    if (!existsSync(rInputs[workflowPath])) return undefined;
     return rInputs[workflowPath];
   }
 

--- a/src/managers/WorkflowManager.ts
+++ b/src/managers/WorkflowManager.ts
@@ -3,11 +3,18 @@ import * as vscode from "vscode";
 import { WorkflowData, WorkflowJson } from "../types";
 import parseJson from "../utils/parseJson";
 import { OpenfnRcManager } from "./OpenfnRcManager";
+import { runWorkflowHelper } from "../workflowRunner";
 
 interface ActiveFileMeta {
   isJob: boolean;
   document: vscode.TextDocument;
   adaptor: string | undefined;
+}
+
+const RECENT_INPUTS_KEY = "recent_inputs";
+
+interface InputPickItem extends vscode.QuickPickItem {
+  id: string;
 }
 
 export class WorkflowManager implements vscode.Disposable {
@@ -19,7 +26,11 @@ export class WorkflowManager implements vscode.Disposable {
   private watcher!: vscode.FileSystemWatcher;
   workflowFiles: WorkflowData[] = [];
   private rcManager: OpenfnRcManager;
-  constructor(public api: typeof vscode, public workspaceUri: vscode.Uri) {
+  constructor(
+    public api: typeof vscode,
+    public workspaceUri: vscode.Uri,
+    private storage: vscode.Memento
+  ) {
     this.rcManager = new OpenfnRcManager(this.workspaceUri);
     this.onAvailabilityChange = this.rcManager.onAvailabilityChange; // hook workspace availability change to .openfnrc manager
     this.watchWorkflows();
@@ -41,6 +52,22 @@ export class WorkflowManager implements vscode.Disposable {
     this.api.window.onDidChangeActiveTextEditor(
       this.emitActiveFileHelper.bind(this)
     );
+
+    // initialize recent workflow execution inputs.
+    const rInputs = storage.get<Record<string, string>>(RECENT_INPUTS_KEY);
+    if (!rInputs) storage.update(RECENT_INPUTS_KEY, {});
+  }
+
+  getWorkflowRecentInput(workflowPath: string) {
+    const rInputs = this.storage.get<Record<string, string>>(RECENT_INPUTS_KEY);
+    if (!rInputs || !rInputs[workflowPath]) return undefined;
+    return rInputs[workflowPath];
+  }
+
+  updateWorkflowRecentInput(workflowPath: string, inputPath: string) {
+    const rInputs = this.storage.get<Record<string, string>>(RECENT_INPUTS_KEY);
+    const newInputs = { ...rInputs, [workflowPath]: inputPath };
+    this.storage.update(RECENT_INPUTS_KEY, newInputs);
   }
 
   get activeFile(): ActiveFileMeta | undefined {
@@ -142,6 +169,53 @@ export class WorkflowManager implements vscode.Disposable {
         document: e.document,
         adaptor: undefined,
       });
+  }
+
+  async runWorkflow(workflowInfo: { path: string; name?: string }) {
+    // show input options & then recent input too
+    const recentInput = this.getWorkflowRecentInput(workflowInfo.path);
+    const sources = (
+      recentInput
+        ? [
+            {
+              label: "Previous Input",
+              detail: recentInput,
+              id: "previous",
+            },
+          ]
+        : []
+    ).concat([
+      {
+        label: "No input",
+        detail: "run workflow without an input. default {}",
+        id: "none",
+      },
+      {
+        label: "Select File...",
+        detail: "select a file from your machine as input source",
+        id: "select",
+      },
+    ]);
+    const result = await this.api.window.showQuickPick<InputPickItem>(sources, {
+      title: "Select input source",
+      canPickMany: false,
+    });
+
+    let inputPath: string | undefined = undefined;
+    if (!result) return;
+    if (result.id === "select") {
+      const selectedUri = await vscode.window.showOpenDialog({
+        canSelectMany: false,
+        openLabel: "Select Input Json File",
+        filters: {
+          "Json Files": ["json"],
+        },
+      });
+      if (selectedUri?.length) inputPath = selectedUri[0].fsPath;
+    } else if (result.id === "previous") inputPath = recentInput;
+
+    if (inputPath) this.updateWorkflowRecentInput(workflowInfo.path, inputPath);
+    runWorkflowHelper(workflowInfo, this.workspaceUri, inputPath);
   }
 
   async openFile(path: vscode.Uri) {

--- a/src/workflowRunner.ts
+++ b/src/workflowRunner.ts
@@ -29,12 +29,13 @@ function isOpenfnCLIAvailable() {
 }
 
 const INSTALL_CLI = "Click to Install";
-export async function runWorkflow(
+export async function runWorkflowHelper(
   workflowInfo: {
     path: string;
     name?: string;
   },
-  workspaceUri: vscode.Uri
+  workspaceUri: vscode.Uri,
+  inputPath?: string
 ) {
   // compute output path here!
   const outputPath = path.join(
@@ -43,6 +44,7 @@ export async function runWorkflow(
       workflowInfo.name || "no-name"
     )}-output.json`
   );
+
   const isAvailable = await isOpenfnCLIAvailable();
   if (!isAvailable) {
     const pick = await vscode.window.showWarningMessage(
@@ -56,7 +58,9 @@ export async function runWorkflow(
     fs.mkdirSync(dirPath, { recursive: true });
     runTerminal(
       "Running workflow",
-      `openfn ${workflowInfo.path} -o ${outputPath}`
+      `openfn ${workflowInfo.path} ${
+        inputPath ? "-s " + inputPath : ""
+      } -o ${outputPath}`
     );
   }
 }


### PR DESCRIPTION
### Description
Allow users to select an input source when about to execute a workflow. 
1. Previous Input - only available when there's a previous input source
2. No Input - runs without an input source
3. Select File... - you get to select where your input json file is.

<img width="1138" alt="Screenshot 2025-02-07 at 2 19 09 PM" src="https://github.com/user-attachments/assets/1eacd908-7391-4175-a655-0d44ae91092b" />

Resolves #7 

Welcome.