### PR TITLE
chore: use vscode@1.75.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openfn-vscode",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openfn-vscode",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "dependencies": {
         "acorn": "^8.14.0",
         "ast-types": "^0.16.1",
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@types/mocha": "^10.0.6",
         "@types/node": "18.x",
-        "@types/vscode": "^1.96.0",
+        "@types/vscode": "^1.75.0",
         "@typescript-eslint/eslint-plugin": "^7.4.0",
         "@typescript-eslint/parser": "^7.4.0",
         "@vscode/test-cli": "^0.0.8",
@@ -24,7 +24,7 @@
         "typescript": "^5.3.3"
       },
       "engines": {
-        "vscode": "^1.96.0"
+        "vscode": "^1.75.0"
       }
     },
     "node_modules/@bcoe/v8-coverage": {

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
   "devDependencies": {
     "@types/mocha": "^10.0.6",
     "@types/node": "18.x",
-    "@types/vscode": "^1.96.0",
+    "@types/vscode": "^1.75.0",
     "@typescript-eslint/eslint-plugin": "^7.4.0",
     "@typescript-eslint/parser": "^7.4.0",
     "@vscode/test-cli": "^0.0.8",


### PR DESCRIPTION
### Description
Since, our min version is `1.75.0` this PR makes sure that we're using that specific version of @types in our codebase. Hence we wouldn't have access to apis that didn't exist after it. support guaranteed!