### PR TITLE
feat: only register active js file to fn language

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
         ],
         "extensions": [
           ".fn",
-          ".js",
           ".ofn",
           ".openfn"
         ],

--- a/src/OpenfnExtension.ts
+++ b/src/OpenfnExtension.ts
@@ -52,6 +52,10 @@ export class OpenFnExtension implements vscode.Disposable {
 
         // deal with completion stuff
         if (activeFile.isJob) {
+          this.workflowManager.api.languages.setTextDocumentLanguage(
+            activeFile.document,
+            "fn"
+          ); // register active file as fn file
           this.completionManager.registerCompletions(activeFile.adaptor);
           this.completionManager.registerHoverSupport(activeFile.adaptor);
           this.completionManager.registerSignatureHelpProvider(


### PR DESCRIPTION
### Description
Sets only job files to `openfn` language. 
Note: It only sets a given job file to `openfn` language when it's opened or active. 
We could get it to set all job files at once (tested by @doc-han) but that will mean loading all those files into memory on-start. Hence, decided to rather set it on demand. 

Resolves #40  