### PR TITLE
feat: allow step to pick input source from workflow.json

### DIFF
--- a/src/OpenfnExtension.ts
+++ b/src/OpenfnExtension.ts
@@ -166,7 +166,9 @@ export class OpenFnExtension implements vscode.Disposable {
         workflowManager.runWorkflow({
           path: item.filePath,
           name: item.label,
-          adaptor: item.adaptor,
+          isStep: !!item.adaptors,
+          adaptors: item.adaptors,
+          state: item.state,
         });
       }
     );

--- a/src/TreeViewProvider.ts
+++ b/src/TreeViewProvider.ts
@@ -40,7 +40,8 @@ export class TreeViewProvider implements vscode.TreeDataProvider<TreeviewItem> {
             path.join(path.dirname(element.filePath), step.expression),
             vscode.TreeItemCollapsibleState.None,
             [], // no steps
-            step.adaptors.map((a) => a.full).join(" + ")
+            step.adaptors.map((a) => a.full),
+            step.state
           )
       );
     }
@@ -48,18 +49,20 @@ export class TreeViewProvider implements vscode.TreeDataProvider<TreeviewItem> {
 }
 
 export class TreeviewItem extends vscode.TreeItem {
+  public readonly command: vscode.Command;
   constructor(
     public readonly label: string,
     public readonly filePath: string,
     public readonly collapsibleState: vscode.TreeItemCollapsibleState,
     public readonly steps: WorkflowData["steps"] = [],
-    public readonly adaptor: string | undefined = undefined,
-    public readonly command?: vscode.Command
+    public readonly adaptors: string[] | undefined = undefined,
+    public readonly state: Record<string, any> | undefined = undefined
   ) {
     super(label, collapsibleState);
     this.tooltip = this.label;
-    const adaptor_name = this.adaptor?.match(/^\w+/)?.[0];
-    if (!adaptor_name) {
+    const adaptor_name = this.adaptors?.join(" + ");
+    const first_adaptor = this.adaptors?.[0]?.match(/^\w+/)?.[0];
+    if (!first_adaptor && !adaptor_name) {
       this.iconPath = path.join(
         __filename,
         "..",
@@ -70,9 +73,9 @@ export class TreeviewItem extends vscode.TreeItem {
     } else {
       // is sub-item
       this.iconPath = vscode.Uri.parse(
-        `https://app.openfn.org/images/adaptors/${adaptor_name}-square.png`
+        `https://app.openfn.org/images/adaptors/${first_adaptor}-square.png`
       );
-      this.description = this.adaptor;
+      this.description = adaptor_name;
     }
     this.contextValue = "workflow.item";
     this.command = {

--- a/src/workflowRunner.ts
+++ b/src/workflowRunner.ts
@@ -46,7 +46,7 @@ export async function runWorkflowHelper(
   workflowInfo: {
     path: string;
     name?: string;
-    adaptor?: string;
+    adaptors?: string[];
   },
   workspaceUri: vscode.Uri,
   inputPath?: string
@@ -68,7 +68,9 @@ export async function runWorkflowHelper(
       `openfn ${workflowInfo.path} ${
         inputPath ? "-s " + inputPath : ""
       } -o ${outputPath} ${
-        workflowInfo.adaptor ? "-a " + workflowInfo.adaptor : ""
+        workflowInfo.adaptors?.length
+          ? workflowInfo.adaptors.map((a) => "-a " + a).join(" ")
+          : ""
       }`
     );
   }


### PR DESCRIPTION
### Description
When running a step, the input source might be part of the workflow.json as a state key on the step. This PR allows you to pick that also as an input source when running a single step. 

**Look at the second option below**

<img width="796" alt="Screenshot 2025-02-27 at 3 23 34 PM" src="https://github.com/user-attachments/assets/90f3d831-e399-44e3-bd2a-4937986ad4b5" />
